### PR TITLE
Improve version number generation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Pick version number
       id: pick_version_number
       run: |
-        VALID_VERSION_REGEX="v[0-9]+\.[0-9]+\.[0-9](-[A-Za-z0-9]+)?$"
+        VALID_VERSION_REGEX="^[0-9]+\.[0-9]+\.[0-9](-[A-Za-z0-9]+)?$"
 
         if [ ! -z "${MANUAL_VERSION}" ] ; then
           echo "User supplied version: ${MANUAL_VERSION}"


### PR DESCRIPTION
- Take version number from input parameter if supplied
- Validate version number against a regex to guard against invalid user input
- Publish built package to NuGet on manually triggered builds