### PR TITLE
Add concatenation support

### DIFF
--- a/ghul-pipes/CatPipe.cs
+++ b/ghul-pipes/CatPipe.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pipes
+{
+    public class CatPipe<T>: Pipe<T>
+    {
+        private readonly IEnumerator<T> left;
+        private readonly IEnumerator<T> right;
+        private bool takeFromLeft;
+
+        public CatPipe(IEnumerator<T> left, IEnumerator<T> right) : base(null) {
+            this.left = left;
+            this.right = right;
+            takeFromLeft = true;
+        }
+        public override bool MoveNext() {
+            if (takeFromLeft) {
+                takeFromLeft = left.MoveNext();
+
+                if (takeFromLeft) {
+                    return true;
+                }
+
+                left.Reset();
+            }
+
+            var result = right.MoveNext();
+
+            if (result) {
+                return true;
+            }
+
+            takeFromLeft = true;
+            right.Reset();
+
+            return false;
+        }
+
+        public override T Current { get => takeFromLeft ? left.Current : right.Current; }
+
+        public override void Reset() {
+            left.Reset();
+            right.Reset();
+
+            takeFromLeft = true;
+        }
+    }
+}

--- a/ghul-pipes/Pipe.cs
+++ b/ghul-pipes/Pipe.cs
@@ -40,6 +40,9 @@ namespace Pipes
         public Pipe<T> Take(int takeCount) => 
             new TakePipe<T>(GetEnumerator(), takeCount);
 
+        public Pipe<T> Cat(IEnumerable<T> right) =>
+            new CatPipe<T>(GetEnumerator(), right.GetEnumerator());
+
         public IReadOnlyList<T> Collect() => CollectList();
 
         public T[] CollectArray() => CollectList().ToArray();
@@ -121,6 +124,7 @@ namespace Pipes
 
         public virtual Pipe<T> Sort(Func<T,T,int> compare) => Sort(new FunctionComparer<T>(compare));
 
+        // Deprecated - reserve 'Join' for joining two pipes on a key:
         public virtual string Join(string separator) {
             var result = new System.Text.StringBuilder();
             var seen_any = false;
@@ -140,7 +144,29 @@ namespace Pipes
             return result.ToString();
         }
 
-        public virtual string Join() => Join(",");
+        // Deprecated - reserve 'Join' for joining two pipes on a key:
+        public virtual string Join() => Join(", ");
+
+        public virtual string ToString(string separator) {
+            var result = new System.Text.StringBuilder();
+            var seen_any = false;
+
+            while(MoveNext()) {
+                if (seen_any) {
+                    result.Append(separator);
+                }
+
+                result.Append(Current);
+
+                seen_any = true;
+            }
+
+            Reset();
+
+            return result.ToString();
+        }
+
+        public override string ToString() => ToString(", ");
 
         #region function comparer
         private class FunctionComparer<U>: IComparer<U> {

--- a/ghul-pipes/ghul-pipes.csproj
+++ b/ghul-pipes/ghul-pipes.csproj
@@ -8,7 +8,7 @@
     <PackageId>ghul.pipes</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.4-alpha.5</Version>
+    <Version>0.0.5-alpha.1</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>  
     <RepositoryUrl>https://github.com/degory/ghul-pipes</RepositoryUrl>

--- a/tests/CatPipeTests.cs
+++ b/tests/CatPipeTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+
+using Pipes;
+
+namespace Tests
+{
+    [TestClass]
+    public class CatPipeShould
+    {
+
+       [TestMethod]
+        public void Cat_EmptySequences_ReturnsEmptySequence()
+        {
+            var pipe = Pipe.From(new int[0]).Cat(new int[0]);
+
+            pipe
+                .Count()
+                .Should()
+                .Be(0);
+        }
+
+        [TestMethod]
+        public void Cat_EmptyPlusNonEmpty_ReturnsSecondSequence()
+        {
+            var pipe = Pipe.From(new int[0]).Cat(new [] {1, 2, 3, 4, 5});
+
+            pipe
+                .Should()
+                .Equal(new []{ 1, 2, 3, 4, 5 });
+        }
+
+        [TestMethod]
+        public void Cat_NonEmptyPlusEmpty_ReturnsFirstSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5}).Cat(new int[0]);
+
+            pipe
+                .Should()
+                .Equal(new []{ 1, 2, 3, 4, 5 });
+        }
+
+
+        [TestMethod]
+        public void Cat_NonEmptyPlusNonEmpty_ReturnsBothSequencesInOrder()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5}).Cat(new [] {6, 7, 8, 9, 10});
+
+            pipe
+                .Should()
+                .Equal(new []{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        }
+
+        [TestMethod]
+        public void Cat_ChainedCalls_ReturnsConcatenationOfAllInputs()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5});
+
+            pipe
+                .Cat(new [] {1, 2, 1})
+                .Cat(new int[0])
+                .Cat(new [] {2, 3, 4})
+                .Cat(new [] {5})
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+        }
+
+        [TestMethod]
+        public void Cat_ChainedCalls_CountReturnsSumOfAllCounts()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5});
+
+            pipe
+                .Cat(new [] {1, 2, 1})
+                .Cat(new int[0])
+                .Cat(new [] {2, 3, 4})
+                .Cat(new [] {5})
+                .Count()
+                .Should()
+                .Be(10);
+        }
+
+    }
+}

--- a/tests/FilterPipeTests.cs
+++ b/tests/FilterPipeTests.cs
@@ -57,6 +57,19 @@ namespace Tests
         }
 
         [TestMethod]
+        public void Filter_CalledTwice_ReturnsOnlyElementsThatMatchBothPredicates()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Filter(i => i > 3 && i < 9)
+                .Filter(i => (i & 1) == 0)
+                .Should()
+                .Equal(new [] { 4, 6, 8 });
+        }
+
+
+        [TestMethod]
         public void Count_AlwaysTruePredicate_ReturnsElementCount()
         {
             var input = new [] {"a", "b", "c", "d"};

--- a/tests/MapPipeTests.cs
+++ b/tests/MapPipeTests.cs
@@ -32,5 +32,17 @@ namespace Tests
                 .Should()
                 .Equal(new [] {6, 8, 2, 10, 4, 6, 2, 8, 10});
         }
+
+        [TestMethod]
+        public void Map_CalledTwice_AppliesBothFunctionsToEveryElementInCorrectOrder()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6});
+
+            pipe
+                .Map(i => i + "-first")
+                .Map(i => i + "-second")
+                .Should()
+                .Equal(new [] { "1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second" });
+        }
     }
 }

--- a/tests/PipeTests.cs
+++ b/tests/PipeTests.cs
@@ -10,150 +10,6 @@ namespace Tests
     public class PipeShould
     {
         [TestMethod]
-        public void Pipe_SkipThenFirst_ReturnsCorrectElement()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Skip(5)
-                .First()
-                .Should()
-                .Be(6);
-        }
-
-        [TestMethod]
-        public void Pipe_TakeThenFirst_ReturnsFirstElement()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Take(5)
-                .First()
-                .Should()
-                .Be(1);
-        }
-
-        [TestMethod]
-        public void Pipe_SkipThenFilter_ReturnsFilteredTailSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Skip(5)
-                .Filter(i => (i & 1) == 0)
-                .Should()
-                .Equal(new [] { 6, 8, 10 });
-        }
-
-        [TestMethod]
-        public void Pipe_FilterThenSkip_ReturnsFilteredTailSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Filter(i => (i & 1) == 0)
-                .Skip(1)
-                .Should()
-                .Equal(new [] { 4, 6, 8, 10 });
-        }
-
-        [TestMethod]
-        public void Pipe_TakeThenFilter_ReturnsFilteredHeadSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Take(5)
-                .Filter(i => (i & 1) == 0)
-                .Should()
-                .Equal(new [] { 2, 4 });
-        }
-
-        [TestMethod]
-        public void Pipe_FilterThenTake_ReturnsFilteredHeadSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Filter(i => (i & 1) == 0)
-                .Take(3)
-                .Should()
-                .Equal(new [] { 2, 4, 6 });
-        }
-
-        [TestMethod]
-        public void Pipe_SkipThenMap_ReturnsMappedTailSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Skip(5)
-                .Map(i => "X" + i)
-                .Should()
-                .Equal(new [] { "X6", "X7", "X8", "X9", "X10" });
-        }
-
-        [TestMethod]
-        public void Pipe_MapThenSkip_ReturnsMappedTailSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Map(i => "X" + i)
-                .Skip(5)
-                .Should()
-                .Equal(new [] { "X6", "X7", "X8", "X9", "X10" });
-        }
-
-        [TestMethod]
-        public void Pipe_TakeThenMap_ReturnsMappedHeadSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Take(4)
-                .Map(i => "X" + i)
-                .Should()
-                .Equal(new [] { "X1", "X2", "X3", "X4" });
-        }
-
-        [TestMethod]
-        public void Pipe_MapThenTake_ReturnsMappedHeadSequence()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Map(i => "X" + i)
-                .Take(6)
-                .Should()
-                .Equal(new [] { "X1", "X2", "X3", "X4", "X5", "X6" });
-        }
-
-        [TestMethod]
-        public void Pipe_FilterThenFilter_ReturnsOnlyElementsThatMatchBothPredicates()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-
-            pipe
-                .Filter(i => i > 3 && i < 9)
-                .Filter(i => (i & 1) == 0)
-                .Should()
-                .Equal(new [] { 4, 6, 8 });
-        }
-
-        [TestMethod]
-        public void Pipe_MapThenMap_AppliesBothFunctionsToEveryElementInCorrectOrder()
-        {
-            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6});
-
-            pipe
-                .Map(i => i + "-first")
-                .Map(i => i + "-second")
-                .Should()
-                .Equal(new [] { "1-first-second", "2-first-second", "3-first-second", "4-first-second", "5-first-second", "6-first-second" });
-        }
-
-        [TestMethod]
         public void Sort_NoComparer_SortsInDefaultOrder()
         {
             var pipe = Pipe.From(new [] {2, 1, 4, 3, 6, 5});
@@ -215,19 +71,40 @@ namespace Tests
         }
 
         [TestMethod]
-        public void Join_CalledTwice_JoinsAllElements()
+        public void ToString_WithNoSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithACommaAndSpace()
         {
             var pipe = Pipe.From(new [] {2, 1, 4, 3, 6, 5});
 
             pipe
-                .Join();
-
-            pipe
-                .Join(", ")
+                .ToString()
                 .Should()
                 .Be("2, 1, 4, 3, 6, 5");
         }
 
+        [TestMethod]
+        public void ToString_WithSeparatorArgument_ReturnsStringRepresentationOfAllElementsSeparatedWithThatSeparator()
+        {
+            var pipe = Pipe.From(new [] {2, 1, 4, 3, 6, 5});
+
+            pipe
+                .ToString("///")
+                .Should()
+                .Be("2///1///4///3///6///5");
+        }
+
+        [TestMethod]
+        public void ToString_CalledTwice_ReturnsStringRepresentationOfAllElements()
+        {
+            var pipe = Pipe.From(new [] {2, 1, 4, 3, 6, 5});
+
+            pipe
+                .ToString();
+
+            pipe
+                .ToString("\t")
+                .Should()
+                .Be("2\t1\t4\t3\t6\t5");
+        }
 
         class ReverseIntComparer: System.Collections.Generic.IComparer<int>
         {

--- a/tests/PipelinesTests.cs
+++ b/tests/PipelinesTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using FluentAssertions;
+
+using Pipes;
+
+namespace Tests
+{
+    [TestClass]
+    public class PipelinesShould
+    {
+        [TestMethod]
+        public void Pipe_SkipThenFirst_ReturnsCorrectElement()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Skip(5)
+                .First()
+                .Should()
+                .Be(6);
+        }
+
+        [TestMethod]
+        public void Pipe_TakeThenFirst_ReturnsFirstElement()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Take(5)
+                .First()
+                .Should()
+                .Be(1);
+        }
+
+        [TestMethod]
+        public void Pipe_SkipThenFilter_ReturnsFilteredTailSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Skip(5)
+                .Filter(i => (i & 1) == 0)
+                .Should()
+                .Equal(new [] { 6, 8, 10 });
+        }
+
+        [TestMethod]
+        public void Pipe_FilterThenSkip_ReturnsFilteredTailSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Filter(i => (i & 1) == 0)
+                .Skip(1)
+                .Should()
+                .Equal(new [] { 4, 6, 8, 10 });
+        }
+
+        [TestMethod]
+        public void Pipe_TakeThenFilter_ReturnsFilteredHeadSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Take(5)
+                .Filter(i => (i & 1) == 0)
+                .Should()
+                .Equal(new [] { 2, 4 });
+        }
+
+        [TestMethod]
+        public void Pipe_FilterThenTake_ReturnsFilteredHeadSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Filter(i => (i & 1) == 0)
+                .Take(3)
+                .Should()
+                .Equal(new [] { 2, 4, 6 });
+        }
+
+        [TestMethod]
+        public void Pipe_SkipThenMap_ReturnsMappedTailSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Skip(5)
+                .Map(i => "X" + i)
+                .Should()
+                .Equal(new [] { "X6", "X7", "X8", "X9", "X10" });
+        }
+
+        [TestMethod]
+        public void Pipe_MapThenSkip_ReturnsMappedTailSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Map(i => "X" + i)
+                .Skip(5)
+                .Should()
+                .Equal(new [] { "X6", "X7", "X8", "X9", "X10" });
+        }
+
+        [TestMethod]
+        public void Pipe_TakeThenMap_ReturnsMappedHeadSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Take(4)
+                .Map(i => "X" + i)
+                .Should()
+                .Equal(new [] { "X1", "X2", "X3", "X4" });
+        }
+
+        [TestMethod]
+        public void Pipe_MapThenTake_ReturnsMappedHeadSequence()
+        {
+            var pipe = Pipe.From(new [] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+            pipe
+                .Map(i => "X" + i)
+                .Take(6)
+                .Should()
+                .Equal(new [] { "X1", "X2", "X3", "X4", "X5", "X6" });
+        }
+    }
+}

--- a/tests/SkipPipeTests.cs
+++ b/tests/SkipPipeTests.cs
@@ -120,14 +120,12 @@ namespace Tests
             var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
 
             pipe
-                .Skip(7);
-
-            // expect pipe reset
+                .Skip(7)
+                .Collect();
 
             pipe
-                .Skip(6);
-
-            // expect pipe reset - skipping 5 elements still leaves 5 elements to consume:
+                .Skip(6)
+                .Collect();
 
             pipe
                 .Skip(5)

--- a/tests/TakePipeTests.cs
+++ b/tests/TakePipeTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+
+using Pipes;
+
+namespace Tests
+{
+    [TestClass]
+    public class TakePipeShould
+    {
+
+       [TestMethod]
+        public void Take_NegativeTakeCount_ReturnsEmptySequence()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(-27)
+                .Should()
+                .Equal(new int[0]);
+        }
+
+        [TestMethod]
+        public void Take_ZeroTakeCount_ReturnsEmptySequence()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(0)
+                .Should()
+                .Equal(new int[0]);
+        }
+
+        [TestMethod]
+        public void Take_TakeCountEqualToLength_ReturnsWholeInput()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(10)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+        }
+
+        [TestMethod]
+        public void Take_TakeCountOneGreaterThanLength_ReturnsWholeInput()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(11)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+        }
+
+        [TestMethod]
+        public void Take_TakeCountSomewhatGreaterThanLength_ReturnsWholeInput()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(15)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+        }
+
+        [TestMethod]
+        public void Take_TakeCountMuchGreaterThanLength_ReturnsWholeInput()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(1000)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+        }
+
+        [TestMethod]
+        public void Take_TakeOne_ReturnsFirstElementAsSequence()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(1)
+                .Should()
+                .Equal(new [] {3});
+        }
+
+        [TestMethod]
+        public void Take_TakeMultiple_ReturnsCorrectHeadSequence()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(4)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1});
+        }
+
+        [TestMethod]
+        public void Take_TakeOneLessThanLength_ReturnsCorrectHeadSequence()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(9)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4});
+        }
+
+        [TestMethod]
+        public void Take_ChainedCalls_TakesMinimumOfTakeCountsElements()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(7)
+                .Take(2)
+                .Take(4)
+                .Should()
+                .Equal(new [] {3, 4});
+        }
+
+        [TestMethod]
+        public void Take_ChainedCallsWithCountGreaterThanInputLength_TakesMiniumnOfTakeCountsElements()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(7)
+                .Take(27)
+                .Take(5)
+                .Take(1000)
+                .Should()
+                .Equal(new [] {3, 4, 5, 1, 2});
+        }
+ 
+        [TestMethod]
+        public void Take_TakeAfterPriorEnumerate_PipeIsReset()
+        {
+            var pipe = Pipe.From(new [] {3, 4, 5, 1, 2, 1, 2, 3, 4, 5});
+
+            pipe
+                .Take(7)
+                .Collect();
+
+            pipe
+                .Take(6)
+                .Collect();
+
+            pipe
+                .Take(5)
+                .Should()
+                .Equal(new [] { 3, 4, 5, 1, 2 });
+        }
+    }
+}


### PR DESCRIPTION
- Add `Cat` method, which returns the concatenation of a pipe and an enumerable
- Add `ToString` method and deprecate `Join` (which also converts a Pipe to a string representation, but want to use 'Join' name for joining two pipes on a key)