### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,20 +19,27 @@ env:
 jobs:
   version:
     name: Create a version number
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     outputs:
       tag: ${{ steps.create_version.outputs.tag }}
       package: ${{ steps.create_version.outputs.package }}
+      
+    permissions:
+      contents: 'write'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'    
 
     - name: Create version
       id: create_version
-      uses: degory/create-version@v0.0.1
+      uses: degory/create-version@v0.0.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        PRERELEASE: ${{ github.event_name == 'pull_request' }}
 
   build:
     name: Build, test, and publish package
@@ -42,7 +49,7 @@ jobs:
     needs: [version]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
                     
     - name: Pack
       run: dotnet pack ghul-pipes -p:Version=${{ needs.version.outputs.package }}
@@ -51,7 +58,7 @@ jobs:
       run: dotnet test tests
 
     - name: Upload .NET package artefact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: package
         path: ghul-pipes/nupkg
@@ -77,10 +84,10 @@ jobs:
     if: ${{ github.event_name == 'push' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: package
         path: nupkg

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     name: Build, test, and publish package
     runs-on: ubuntu-latest
-    container: ghul/devcontainer:dotnet
+    container: mcr.microsoft.com/dotnet/sdk:8.0
     timeout-minutes: 10
     needs: [version]
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -65,13 +65,13 @@ jobs:
 
     - name: Publish package to GitHub
       if: ${{ github.actor != 'dependabot[bot]' }}
-      run: dotnet nuget push ./ghul-pipes/nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./ghul-pipes/nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish package to NuGet
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      run: dotnet nuget push ./ghul-pipes/nupkg/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./ghul-pipes/nupkg/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.1.0-alpha.1</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ghul-pipes
 
-[![CI/CD](https://img.shields.io/github/workflow/status/degory/ghul-pipes/CI)](https://github.com/degory/ghul-pipes/actions?query=workflow%3ACI)
+[![CI/CD](https://img.shields.io/github/actions/workflow/status/degory/ghul-pipes/cicd.yml?branch=main)](https://github.com/degory/ghul-pipes/actions?query=branch%3Amain)
 [![NuGet version (ghul.pipes)](https://img.shields.io/nuget/v/ghul.pipes.svg)](https://www.nuget.org/packages/ghul.pipes/)
 [![Release](https://img.shields.io/github/v/release/degory/ghul-pipes?label=release)](https://github.com/degory/ghul-pipes/releases)
 [![Release Date](https://img.shields.io/github/release-date/degory/ghul-pipes)](https://github.com/degory/ghul-pipes/releases)
 [![Issues](https://img.shields.io/github/issues/degory/ghul-pipes)](https://github.com/degory/ghul-pipes/issues) 
 [![License](https://img.shields.io/github/license/degory/ghul-pipes)](https://github.com/degory/ghul-pipes/blob/main/LICENSE)
 
-Provides implementations of the [pipe operator and filter, map and reduce functions](https://github.com/degory/ghul-pipes-examples/blob/main/src/ghul-pipes-examples.ghul) for the [ghūl programming language](https://ghul.io)
+Provides implementations of the [pipe operator and filter, map and reduce functions](https://github.com/degory/ghul-examples/blob/main/pipes/pipes.ghul) for the [ghūl programming language](https://ghul.dev)

--- a/ghul-pipes/ghul-pipes.csproj
+++ b/ghul-pipes/ghul-pipes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Pipes</RootNamespace>
 
     <Title>ghūl pipes library</Title>
@@ -10,7 +10,7 @@
 
     <PackageId>ghul.pipes</PackageId>
     <Authors>degory</Authors>
-    <Company>ghul.io</Company>
+    <Company>ghul.dev</Company>
 
     <DebugType>None</DebugType>    
 

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- Update references to .NET 6 to .NET 8 in project files (see #1037)
- Bump some outdated actions in the GitHub Actions workflow
- Update references to old website to correctly point to https://ghul.dev
- Update broken badge in README.md
- Update reference to pipes example repo to point at the general ghūl examples repo instead

bump #minor