### PR TITLE
Fix broken URLs in project file

### DIFF
--- a/ghul-pipes/ghul-pipes.csproj
+++ b/ghul-pipes/ghul-pipes.csproj
@@ -18,10 +18,10 @@
     <Description>ghūl compiler pipes library</Description>
     <PackageTags>ghul;ghūl;pipes</PackageTags>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageProjectUrl>https://github.com/degory/ghul-pipes</PackageProjectUrl>
+    <PackageProjectUrl>https://ghul.dev</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/degory/ghul-pipes.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/degory/ghul-pipes</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>main</RepositoryBranch>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
- Fix package project URL to point at https://ghul.dev
- Remove .git from the repository URL