### PR TITLE
Prepare for ghūl port

### DIFF
--- a/ghul-pipes/Pipe.cs
+++ b/ghul-pipes/Pipe.cs
@@ -17,6 +17,16 @@ namespace Pipes
         }
     }
 
+    public class Factory {
+        public static Pipe<T> From<T>(IEnumerable<T> source) {
+            if (source != null) {
+                return Pipe<T>.From(source);
+            } else {
+                return null;
+            }
+        }
+    }
+
     public struct Maybe {
         public static Maybe<T> From<T>(T value) => new Maybe<T>(value);
     }


### PR DESCRIPTION
- Prepare to port from C# to ghūl, by creating a new static factory class for the compiler to reference with a different name to differentiate the two implementations